### PR TITLE
Revert "added wait-for-close", update Aleph to alpha8, Fixes #1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,8 @@
-(defproject luminus-aleph "0.1.4"
+(defproject luminus-aleph "0.1.5-SNAPSHOT"
   :description "Aleph adapter for Luminus"
   :url "https://github.com/luminus-framework/luminus-aleph"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.logging "0.3.1"]
-                 [aleph "0.4.2-alpha4"]])
+                 [aleph "0.4.2-alpha8"]])

--- a/src/luminus/http_server.clj
+++ b/src/luminus/http_server.clj
@@ -1,17 +1,13 @@
 (ns luminus.http-server
   (:require [clojure.tools.logging :as log]
-            [aleph.http :as http]
-            [aleph.netty :as netty]))
+            [aleph.http :as http]))
 
 (defn start [{:keys [handler port] :as opts}]
   (try
     (log/info "starting HTTP server on port" port)
-    (let [server (http/start-server
-                   handler
-                   (dissoc opts :handler))]
-      (netty/wait-for-close server)
-      server)
-
+    (http/start-server
+      handler
+      (dissoc opts :handler))
     (catch Throwable t
       (log/error t (str "server failed to start on port " port))
       (throw t))))


### PR DESCRIPTION
Reverts commit 9cb7ac8013eb2f4105b859c4004e9807bec470fc.
Adding `wait-for-close` caused the repl to hang when starting the HTTP server, reverting this change fixes the problem.
Updates the Aleph version.
