### PR TITLE
Bump Aleph to 0.4.7

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]
                  [org.clojure/tools.logging "0.4.1"]
-                 [aleph "0.4.6"]])
+                 [aleph "0.4.7"]])


### PR DESCRIPTION
## Description

As requested three years ago (https://github.com/clj-commons/aleph/issues/504), here is finally a Pull Request regarding the latest
stable version of Aleph (0.4.7 - released 12 days ago).

In any case, we are using `0.4.7-alpha7` in all our (server) projects and it
has never been an issue.

EDIT: I know you are quite busy with `clj-kit` today, but `luminus` is not dead. :)